### PR TITLE
As an Admin I only want to see Enterprise Promotion results in the dashboard when application year 15/16 is selected, so I don’t see unnecessary information

### DIFF
--- a/app/views/assessor/form_answers/_category_tabs.html.slim
+++ b/app/views/assessor/form_answers/_category_tabs.html.slim
@@ -2,6 +2,11 @@
   .nav-subnav
     ul
       - category_picker.visible_categories.each do |category|
-        li class="cat-#{category.text_label.parameterize} #{'active' if category.active?(params)}" role="presentation"
-          = link_to category.text_label, assessor_form_answers_path(award_type: category.slug, year: @award_year.year)
+        - if params[:year] == "2016"
+          li class="cat-#{category.text_label.parameterize} #{'active' if category.active?(params)}" role="presentation"
+            = link_to category.text_label, assessor_form_answers_path(award_type: category.slug, year: @award_year.year)
+        - else
+          - unless category.slug == "promotion"
+            li class="cat-#{category.text_label.parameterize} #{'active' if category.active?(params)}" role="presentation"
+              = link_to category.text_label, assessor_form_answers_path(award_type: category.slug, year: @award_year.year)
     .clear

--- a/app/views/assessor/form_answers/_category_tabs.html.slim
+++ b/app/views/assessor/form_answers/_category_tabs.html.slim
@@ -2,11 +2,7 @@
   .nav-subnav
     ul
       - category_picker.visible_categories.each do |category|
-        - if params[:year] == "2016"
+        - if params[:year] == "2016" || (params[:year] != "2016" && category.slug != "promotion")
           li class="cat-#{category.text_label.parameterize} #{'active' if category.active?(params)}" role="presentation"
             = link_to category.text_label, assessor_form_answers_path(award_type: category.slug, year: @award_year.year)
-        - else
-          - unless category.slug == "promotion"
-            li class="cat-#{category.text_label.parameterize} #{'active' if category.active?(params)}" role="presentation"
-              = link_to category.text_label, assessor_form_answers_path(award_type: category.slug, year: @award_year.year)
     .clear


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/Ol6DZNom/455-as-an-admin-i-only-want-to-see-enterprise-promotion-results-in-the-dashboard-when-application-year-15-16-is-selected-so-i-don-t-)

[ASSESSOR APPLICATIONS] removed category tab "Enterprise Promotion" from top bar since 2017