### PR TITLE
[QAE16IMP] In the Entries Report, the Product Service column is pulling the wrong info

### DIFF
--- a/app/models/reports/data_pickers/form_document_picker.rb
+++ b/app/models/reports/data_pickers/form_document_picker.rb
@@ -213,7 +213,7 @@ module Reports::DataPickers::FormDocumentPicker
     if innovation?
       doc "innovation_desc_short"
     elsif development?
-      doc "development_desc_short"
+      doc "development_management_approach_briefly"
     elsif mobility?
       doc "development_desc_short"
     else


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/3V9TxIDI/599-qae16imp-in-the-entries-report-the-product-service-column-is-pulling-the-wrong-info)

[ADMIN REPORTS] fixed issue with the wrong info in the Product Service column of the Sustainable Development