### PR TITLE
As an Assessor I want to see the number of notes and comments that have been made, so I don’t have to expand each of these sections to check if there have been any new ones added

### DIFF
--- a/app/assets/javascripts/admin/comments.js.coffee
+++ b/app/assets/javascripts/admin/comments.js.coffee
@@ -1,6 +1,9 @@
 ready = ->
   $('body').on 'submit', '.new_comment', (e) ->
     that = $(this)
+    commentsContainer = that.closest(".comments-container")
+    counterSpan = that.parents(".panel-body").find(".js-comments-counter")
+
     e.preventDefault()
     $.ajax
       url: $(this).attr('action'),
@@ -13,12 +16,22 @@ ready = ->
         that.find("input[type='checkbox']").prop("checked", false)
         that.find(".comment-actions").removeClass("comment-flagged")
 
+        amountComments = "(" + commentsContainer.find(".comment").length.toString() + ")"
+        counterSpan.text(amountComments)
+
   $('body').on 'submit', '.destroy-comment', (e) ->
     e.preventDefault()
+
+    commentsContainer = $(this).closest(".comments-container")
+    counterSpan = $(this).parents(".panel-body").find(".js-comments-counter")
+
     $.ajax
       url: $(this).attr('action'),
       type: 'DELETE'
     $(this).parents('.comment').remove()
+
+    amountComments = "(" + commentsContainer.find(".comment").length.toString() + ")"
+    counterSpan.text(amountComments)
 
   toggleFlagged()
   deleteCommentAlert()

--- a/app/assets/javascripts/admin/comments.js.coffee
+++ b/app/assets/javascripts/admin/comments.js.coffee
@@ -1,8 +1,6 @@
 ready = ->
   $('body').on 'submit', '.new_comment', (e) ->
     that = $(this)
-    commentsContainer = that.closest(".comments-container")
-    counterSpan = that.parents(".panel-body").find(".js-comments-counter")
 
     e.preventDefault()
     $.ajax
@@ -16,25 +14,26 @@ ready = ->
         that.find("input[type='checkbox']").prop("checked", false)
         that.find(".comment-actions").removeClass("comment-flagged")
 
-        amountComments = "(" + commentsContainer.find(".comment").length.toString() + ")"
-        counterSpan.text(amountComments)
+        updateCommentsCounter(that.closest(".comments-container"))
 
   $('body').on 'submit', '.destroy-comment', (e) ->
     e.preventDefault()
-
     commentsContainer = $(this).closest(".comments-container")
-    counterSpan = $(this).parents(".panel-body").find(".js-comments-counter")
 
     $.ajax
       url: $(this).attr('action'),
       type: 'DELETE'
     $(this).parents('.comment').remove()
 
-    amountComments = "(" + commentsContainer.find(".comment").length.toString() + ")"
-    counterSpan.text(amountComments)
+    updateCommentsCounter(commentsContainer)
 
   toggleFlagged()
   deleteCommentAlert()
+
+updateCommentsCounter = (commentsContainer) ->
+  counterSpan = commentsContainer.parents(".panel-body").find(".js-comments-counter")
+  amountComments = "(" + commentsContainer.find(".comment").length.toString() + ")"
+  counterSpan.text(amountComments)
 
 toggleFlagged = ->
   $(document).on "click", ".js-link-flag-comment", (e) ->

--- a/app/views/admin/form_answers/_section_admin_comments.html.slim
+++ b/app/views/admin/form_answers/_section_admin_comments.html.slim
@@ -3,6 +3,8 @@
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-application-info" href="#section-admin-comments" aria-expanded="true" aria-controls="section-admin-comments"
         ' Admin Comments
+        span.js-comments-counter
+          ' (#{@form_answer.comments.admin.count})
   #section-admin-comments.section-admin-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="admin-comments-heading"
     .panel-body
       .comments-container data-comment-form=new_admin_form_answer_comment_path(@form_answer)

--- a/app/views/admin/form_answers/_section_critical_comments.html.slim
+++ b/app/views/admin/form_answers/_section_critical_comments.html.slim
@@ -3,6 +3,8 @@
     h4.panel-title
       a data-toggle="collapse" data-parent="#panel-assessment" href="#section-critical-comments" aria-expanded="true" aria-controls="section-critical-comments"
         ' Critical Comments
+        span.js-comments-counter
+          ' (#{@form_answer.comments.critical.count})
   #section-critical-comments.section-critical-comments.panel-collapse.collapse role="tabpanel" aria-labelledby="critical-comments-heading"
     .panel-body
       .comments-container.comment-assessor


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/hAXMlwdz/470-as-an-assessor-i-want-to-see-the-number-of-notes-and-comments-that-have-been-made-so-i-don-t-have-to-expand-each-of-these-sectio)

[ADMIN APPLICATIONS] added admin and critical comments counter
![ezgif com-video-to-gif 1](https://cloud.githubusercontent.com/assets/15632598/23075015/4c3696dc-f554-11e6-8340-a1063864a955.gif)
