### PR TITLE
As an Applicant I want the help copy on the online application form to exactly match the help copy on the pdf application form, so that the experience is the same no matter what format I use

### DIFF
--- a/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
+++ b/app/pdf_generators/qae_pdf_forms/general/question_pointer.rb
@@ -235,7 +235,7 @@ class QaePdfForms::General::QuestionPointer
   end
 
   def render_question_context
-    if question.context.present? && urn_blank_or_pdf_blank_mode?
+    if question.context.present?
       render_context_or_help_block(question.escaped_context)
     end
   end
@@ -271,7 +271,8 @@ class QaePdfForms::General::QuestionPointer
       form_pdf.render_text context,
                            style: :bold
     else
-      form_pdf.render_text context
+      form_pdf.render_text context,
+                           style: :italic
     end
   end
 


### PR DESCRIPTION
[TRELLO CARD](https://vk.com/away.php?to=https%3A%2F%2Ftrello.com%2Fc%2FKtd5y60K%2F549-as-an-applicant-i-want-the-help-copy-on-the-online-application-form-to-exactly-match-the-help-copy-on-the-pdf-application-form-s)

[FORM PDF] corrected pdf application form