### PR TITLE
As an Admin/Assessor I don't want to be able to see or interact with the main menu CTAs when I view a user's application online, so I don't accidentally try and access a user's account when I am trying to access my own account

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -59,12 +59,13 @@
           - if current_admin || current_user || current_assessor
             ul#proposition-links
               - if current_admin || current_user.try(:completed_registration)
-                li
-                  = link_to "Applications", dashboard_path
-                li
-                  = link_to "Account details", correspondent_details_account_path
-                li
-                  = link_to "Collaborators", account_collaborators_path
+                - unless admin_in_read_only_mode?
+                  li
+                    = link_to "Applications", dashboard_path
+                  li
+                    = link_to "Account details", correspondent_details_account_path
+                  li
+                    = link_to "Collaborators", account_collaborators_path
               li
                 - if current_admin
                   = link_to "Sign out", destroy_admin_session_path, method: :delete


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/ukSESHae/539-as-an-admin-assessor-i-don-t-want-to-be-able-to-see-or-interact-with-the-main-menu-ctas-when-i-view-a-user-s-application-online-)

[ADMINS AREA] changed the applications overview menu